### PR TITLE
Weird error on build

### DIFF
--- a/cryptfshw/1.0/Android.bp
+++ b/cryptfshw/1.0/Android.bp
@@ -3,7 +3,7 @@
 hidl_interface {
     name: "vendor.qti.hardware.cryptfshw@1.0",
     root: "vendor.qti.hardware.cryptfshw",
-    product_specific: true,
+    system_ext_specific: true,
     srcs: [
         "ICryptfsHw.hal",
     ],
@@ -12,4 +12,3 @@ hidl_interface {
     ],
     gen_java: true,
 }
-


### PR DESCRIPTION
Change-Id: I96721545d7269cda89a3f4e6e94257656d3afeac

error: vendor/qcom/opensource/cryptfs_hw/Android.bp:14:1: dependency "vendor.qti.hardware.cryptfshw@1.0" of "libcryptfs_hw" missing variant:
  os:android, image:, arch:arm64_armv8-a, sdk:, link:shared, version:
available variants:
  os:android, image:product.30, arch:arm64_armv8-a, sdk:, link:shared, version:
  os:android, image:product.30, arch:arm64_armv8-a, sdk:, link:static, version:
  os:android, image:product.30, arch:arm_armv8-a, sdk:, link:shared, version:
  os:android, image:product.30, arch:arm_armv8-a, sdk:, link:static, version:
  os:android, image:recovery, arch:arm64_armv8-a, sdk:, link:shared
  os:android, image:recovery, arch:arm64_armv8-a, sdk:, link:static
  os:android, image:vendor.30, arch:arm64_armv8-a, sdk:, link:shared, version:
  os:android, image:vendor.30, arch:arm64_armv8-a, sdk:, link:static, version:
  os:android, image:vendor.30, arch:arm_armv8-a, sdk:, link:shared, version:
  os:android, image:vendor.30, arch:arm_armv8-a, sdk:, link:static, version:
  os:linux_glibc, arch:x86, link:shared
  os:linux_glibc, arch:x86, link:static
  os:linux_glibc, arch:x86_64, link:shared
  os:linux_glibc, arch:x86_64, link:static
  os:windows, arch:x86, link:shared
  os:windows, arch:x86, link:static
  os:windows, arch:x86_64, link:shared
  os:windows, arch:x86_64, link:static
17:12:42 soong bootstrap failed with: exit status 1

